### PR TITLE
feat: app errors dialog box and own api key support

### DIFF
--- a/i18n/en/cosmic_ext_forecast.ftl
+++ b/i18n/en/cosmic_ext_forecast.ftl
@@ -35,6 +35,9 @@ search = Search
 cancel = Cancel
 dummy-dialog = Dummy Dialog
 search = Search
+api-key = API Key
+provide-api-key = Some requests require API Key. Press button below or go to https://geocode.maps.co/join/ to create free account.
+create-account = Create free account
 
 # Nav Page
 hourly-forecast = Hourly Forecast

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -39,7 +39,7 @@ pub struct WeatherConfigState {
     #[serde(default)]
     pub expires: Option<chrono::DateTime<chrono::FixedOffset>>,
     /// Date of the last request.
-    /// 
+    ///
     /// Used together with the `If-Modified-Since` request header.
     /// If the weather data has not changed, the response status is `304 Not Modified`.
     #[serde(default)]
@@ -84,6 +84,7 @@ pub struct WeatherConfig {
     pub pressure_units: PressureUnits,
     pub speed_units: SpeedUnits,
     pub app_theme: AppTheme,
+    pub api_key: String,
 }
 
 impl Default for WeatherConfig {
@@ -97,6 +98,7 @@ impl Default for WeatherConfig {
             pressure_units: PressureUnits::Hectopascal,
             speed_units: SpeedUnits::MetersPerSecond,
             app_theme: AppTheme::System,
+            api_key: String::default(),
         }
     }
 }
@@ -142,6 +144,21 @@ impl AppTheme {
                 t
             }
             Self::System => theme::system_preference(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AppError {
+    Location(String),
+    Weather(String),
+}
+
+impl std::fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AppError::Location(err) => write!(f, "{}", err),
+            AppError::Weather(err) => write!(f, "{}", err),
         }
     }
 }

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -19,7 +19,10 @@ pub fn menu_bar<'a>(key_binds: &HashMap<KeyBind, Action>) -> Element<'a, Message
             root(fl!("edit")),
             items(
                 key_binds,
-                vec![Item::Button(fl!("change-city"), Action::ChangeCity)],
+                vec![
+                    Item::Button(fl!("change-city"), Action::ChangeCity),
+                    Item::Button(fl!("api-key"), Action::ChangeApiKey),
+                ],
             ),
         ),
         Tree::with_children(

--- a/src/model/location.rs
+++ b/src/model/location.rs
@@ -22,17 +22,25 @@ impl AsRef<str> for Location {
 }
 
 impl Location {
-    pub async fn get_location_data(query: String) -> Result<Vec<Location>, reqwest::Error> {
-        let params = [("q", query)];
+    pub async fn get_location_data(
+        query: String,
+        key: String,
+    ) -> Result<Vec<Location>, reqwest::Error> {
+        let mut params = vec![("q", query)];
 
-        let geocoding_ans: Vec<Location> = reqwest::Client::new()
+        if !key.is_empty() {
+            params.push(("api_key", key));
+        }
+
+        let response = reqwest::Client::new()
             .get("https://geocode.maps.co/search?".to_string())
             .query(&params)
             .send()
-            .await?
-            .json()
             .await?;
 
-        Ok(geocoding_ans)
+        match response.error_for_status() {
+            Ok(resp) => resp.json::<Vec<Location>>().await,
+            Err(e) => Err(e),
+        }
     }
 }


### PR DESCRIPTION
This commit introduce new dialog with app errors, so instead of printing it to stderr it will display dialog box with information about error, for now it supports getting location and fetching weather errors, but we can add more.

Also we have now ability to set our own api key and use it for future requests. This should close #11 since it's related to api key.

![screenshot-2024-09-13-20-51-16](https://github.com/user-attachments/assets/e2057b14-a6cc-422a-912a-dfff4d03a104)
![screenshot-2024-09-13-20-51-43](https://github.com/user-attachments/assets/c1feede7-2508-4a4f-9868-a92a6ce36634)

